### PR TITLE
Change components to fork by default

### DIFF
--- a/example/Main.jsx
+++ b/example/Main.jsx
@@ -14,7 +14,7 @@
 import ReactDOM from 'react-dom';
 import MainView from './MainView';
 
-@Component({ fork: true })
+@Component
 export class Main {
     render() {
         return <MainView />;

--- a/example/MainView.jsx
+++ b/example/MainView.jsx
@@ -78,7 +78,7 @@ class TodoItem {
     }
 }
 
-@Component({ fork: true, throttleUpdates: false })
+@Component({ throttleUpdates: false })
 export default class MainView {
     @Observable userName;
     @Observable filterCompleted;

--- a/src/BaseComponent.jsx
+++ b/src/BaseComponent.jsx
@@ -133,7 +133,7 @@ export default class Component extends React.PureComponent {
             // Note: We don't error here, because sometimes people decorate a class that's not a component with @Component.
             // If scope is actually used, there will still be an error further down the line, but this warning should help explain it!
             let className = this.constructor.name;
-            console.warn(`\`${className}\` was instantiated at the top-level without a forked scope - please change to @Component({ fork: true })`);
+            console.warn(`\`${className}\` was instantiated at the top-level without a forked scope - \`@Component({ fork: false })\` is not supported for top-level components.`);
         }
 
         // Make sure we dispose after unmounting

--- a/src/BaseVirtualComponent.jsx
+++ b/src/BaseVirtualComponent.jsx
@@ -90,7 +90,7 @@ class LinkedData {
  * A Virtual Component is a special type of component that doesn't render anything to the DOM, but instead exposes a
  * tree of nodes in JavaScript. It still has a render function, but it's not rendered by ReactDOM.
  */
-@Component({ fork: true })
+@Component
 export default class BaseVirtualComponent {
 
     [_dirty] = false;

--- a/src/decorators/Component.jsx
+++ b/src/decorators/Component.jsx
@@ -15,34 +15,43 @@ import PropTypes from 'prop-types';
 import { addAttribute, getEventHandler } from '../internal/AttributeUtils';
 import DecoratorUtils from '@twist/core/src/internal/utils/DecoratorUtils';
 
-let allowedOptions = [ 'fork', 'events', 'throttleUpdates' ];
+// Supported options of @Component, with their default values
+let DEFAULT_OPTIONS = {
+    fork: true,
+    events: [],
+    throttleUpdates: true
+};
 
-export default DecoratorUtils.makeClassDecorator((target, args) => {
-    if (args) {
-        Object.keys(args).forEach(key => {
-            if (allowedOptions.indexOf(key) === -1) {
-                console.warn(`${key} is not a valid option for @Component - ignoring.`);
-                return;
-            }
+export default DecoratorUtils.makeClassDecorator((target, args = {}) => {
 
-            if (key === 'events') {
-                target.prototype[key] = (target.prototype[key] || []).concat(args[key]);
-            }
-            else {
-                target.prototype[key] = args[key];
-            }
-        });
-    }
+    // Set the properties passed in via the @Component arguments (or use the default value)
+    Object.keys(DEFAULT_OPTIONS).forEach(key => {
+        let value = args.hasOwnProperty(key) ? args[key] : DEFAULT_OPTIONS[key];
+        if (key === 'events') {
+            // Special case for events, since we need to concatenate them with events from the superclass
+            target.prototype[key] = (target.prototype[key] || []).concat(value);
+        }
+        else {
+            target.prototype[key] = value;
+        }
+    });
+
+    // If the user passed in properties we don't recognise, emit a warning
+    Object.keys(args).forEach(key => {
+        if (!DEFAULT_OPTIONS.hasOwnProperty(key)) {
+            console.warn(`${key} is not a valid option for @Component - ignoring.`);
+        }
+    });
 
     // Make sure event handlers are defined
     target.prototype.events && target.prototype.events.forEach(eventName => {
         addAttribute(target.prototype, getEventHandler(eventName), PropTypes.func);
     });
 
-    // // Allow scope in the context (both to be passed down and received)
+    // Allow scope in the context (both to be passed down and received)
     target.contextTypes = target.contextTypes || {};
     target.contextTypes.scope = PropTypes.object;
-    if (args && args.fork) {
+    if (target.prototype.fork) {
         target.childContextTypes = target.childContextTypes || {};
         target.childContextTypes.scope = PropTypes.object;
     }

--- a/test/decorators/AttributeTest.jsx
+++ b/test/decorators/AttributeTest.jsx
@@ -28,7 +28,7 @@ describe('@Attribute decorator', () => {
 
         let textElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             @Attribute name = 'Bob' + '';
 
@@ -50,7 +50,7 @@ describe('@Attribute decorator', () => {
 
         let textElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             @Attribute name = 'Bob' + (() => '\'s your uncle')();
 
@@ -68,7 +68,7 @@ describe('@Attribute decorator', () => {
 
         sinon.spy(console, 'warn');
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             @Attribute name = 'Bob'
             @Attribute address = this.name + '_address';
@@ -83,7 +83,7 @@ describe('@Attribute decorator', () => {
 
         let textElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             @Attribute(PropTypes.string) name;
 
@@ -106,7 +106,7 @@ describe('@Attribute decorator', () => {
 
         let textElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             @Attribute('title') name;
 
@@ -122,7 +122,7 @@ describe('@Attribute decorator', () => {
 
     it('@Attribute can have its value set, and calls event property', () => {
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             @Attribute name = 'Bob';
             @Attribute address = 'Unknown';
@@ -154,7 +154,7 @@ describe('@Attribute decorator', () => {
         let textElement;
         let parentComp;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             @Attribute name = 'Bob';
 
@@ -163,9 +163,8 @@ describe('@Attribute decorator', () => {
             }
         }
 
-        @Component({ fork: true })
+        @Component
         class MyContainer {
-
             @Observable name = 'Dave'
 
             render() {

--- a/test/decorators/ComponentTest.jsx
+++ b/test/decorators/ComponentTest.jsx
@@ -27,7 +27,7 @@ describe('@Component decorator', () => {
 
         let textElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             @Attribute name;
 
@@ -50,7 +50,7 @@ describe('@Component decorator', () => {
 
         let textElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             @Attribute name;
 
@@ -80,7 +80,7 @@ describe('@Component decorator', () => {
         let renderCount = 0;
         let textElement;
 
-        @Component({ fork: true })
+        @Component
         class MyNestedComponent {
             @Attribute name;
 
@@ -90,7 +90,7 @@ describe('@Component decorator', () => {
             }
         }
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <MyNestedComponent name={ state.name }/>;
@@ -125,7 +125,7 @@ describe('@Component decorator', () => {
         let renderCount = 0;
         let textElement;
 
-        @Component({ fork: true })
+        @Component
         class MyNestedComponent {
             render() {
                 renderCount++;
@@ -133,7 +133,7 @@ describe('@Component decorator', () => {
             }
         }
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <MyNestedComponent name={ state.name }/>;
@@ -167,14 +167,14 @@ describe('@Component decorator', () => {
 
         let textElement;
 
-        @Component({ fork: true })
+        @Component
         class MyNestedComponent {
             render() {
                 return <div ref={ textElement }>{ this.children }</div>;
             }
         }
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <MyNestedComponent>{ state.name }</MyNestedComponent>;
@@ -200,14 +200,14 @@ describe('@Component decorator', () => {
 
         let textElement;
 
-        @Component({ fork: true })
+        @Component
         class MyNestedComponent {
             render() {
                 return <div ref={ textElement }>{ this.children }</div>;
             }
         }
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <MyNestedComponent>
@@ -236,7 +236,7 @@ describe('@Component decorator', () => {
 
         let textElement;
 
-        @Component({ fork: true })
+        @Component
         class MyNestedComponent {
             @Attribute name;
             render() {
@@ -244,7 +244,7 @@ describe('@Component decorator', () => {
             }
         }
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <g>
@@ -275,7 +275,7 @@ describe('@Component decorator', () => {
             @Observable static name;
         }
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             @Attribute name;
             constructor() {
@@ -301,7 +301,7 @@ describe('@Component decorator', () => {
             }
         }
 
-        @Component({ fork: true })
+        @Component
         class MyRootComponent {
             render() {
                 return <MyComponent name={ Data.name } />;
@@ -339,7 +339,7 @@ describe('@Component decorator', () => {
             }
         }
 
-        @Component({ fork: true })
+        @Component
         class Component3 {
             constructor() {
                 super();
@@ -373,7 +373,7 @@ describe('@Component decorator', () => {
             }
         }
 
-        @Component({ fork: true })
+        @Component
         class Component3 {
             constructor() {
                 super();
@@ -393,13 +393,13 @@ describe('@Component decorator', () => {
 
         sinon.spy(console, 'warn');
 
-        @Component
+        @Component({ fork: false })
         class MyComponent {
         }
 
         render(<MyComponent />);
 
-        assert(console.warn.calledWith('`MyComponent` was instantiated at the top-level without a forked scope - please change to @Component({ fork: true })'));
+        assert(console.warn.calledWith('`MyComponent` was instantiated at the top-level without a forked scope - `@Component({ fork: false })` is not supported for top-level components.'));
         console.warn.restore();
     });
 
@@ -408,7 +408,7 @@ describe('@Component decorator', () => {
         let buttonElement;
         let events = [];
 
-        @Component({ fork: true, events: [ 'accept' ] })
+        @Component({ events: [ 'accept' ] })
         class MyComponent {
             @Attribute name;
 
@@ -431,7 +431,7 @@ describe('@Component decorator', () => {
 
     it('@Component ignores triggering invalid events', () => {
 
-        @Component({ fork: true, events: [ 'accept' ] })
+        @Component({ events: [ 'accept' ] })
         class MyComponent {
             render() {
                 return <div>Test</div>;
@@ -456,7 +456,7 @@ describe('@Component decorator', () => {
     it('@Component can render children', () => {
         let divElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <div ref={ element => divElement = element }>{ this.children }</div>;
@@ -471,7 +471,7 @@ describe('@Component decorator', () => {
     it('@Component can render children with arguments', () => {
         let divElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <div ref={ element => divElement = element }>{ this.renderChildren([ 'Hello' ]) }</div>;
@@ -486,7 +486,7 @@ describe('@Component decorator', () => {
     it('@Component can render named children', () => {
         let divElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <div ref={ element => divElement = element }>{ this.renderChildren('test:content') }</div>;
@@ -501,7 +501,7 @@ describe('@Component decorator', () => {
     it('@Component can render named children with arguments', () => {
         let divElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <div ref={ element => divElement = element }>{ this.renderChildren('test:content', [ 'Hello' ]) }</div>;
@@ -514,7 +514,7 @@ describe('@Component decorator', () => {
     });
 
     it('@Component.renderChildren should throw an error if arguments not an array', () => {
-        @Component({ fork: true })
+        @Component
         class MyComponent {
         }
         assert.throws(() => new MyComponent({}).renderChildren('test:content', 'notanarray'), /args parameter to renderChildren\(\) must be an array/);
@@ -523,7 +523,7 @@ describe('@Component decorator', () => {
     it('@Component can pass through undeclared attributes', () => {
         let divElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             @Attribute x;
 
@@ -540,7 +540,7 @@ describe('@Component decorator', () => {
     it('@Component can pass through undeclared attributes, using a namespace prefix', () => {
         let divElement;
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <div ref={ element => divElement = element }><div { ...this.undeclaredAttributes('ns_') }/></div>;
@@ -575,7 +575,7 @@ describe('@Component decorator', () => {
     it('@Component should give warning if there are no props', () => {
         sinon.spy(console, 'warn');
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             constructor() {
                 super(undefined);
@@ -591,7 +591,7 @@ describe('@Component decorator', () => {
     it('@Component should support a throttleUpdates:false option to update immediately on every change', () => {
         let comp, textElement;
 
-        @Component({ fork: true, throttleUpdates: false })
+        @Component({ throttleUpdates: false })
         class MyComponent {
             @Observable text = 'Hello';
             render() {
@@ -611,7 +611,7 @@ describe('@Component decorator', () => {
     });
 
     it('Rendering undefined is ok', () => {
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 // This would throw in normal React.

--- a/test/decorators/VirtualComponentTest.jsx
+++ b/test/decorators/VirtualComponentTest.jsx
@@ -30,7 +30,7 @@ class Item {
 class List {
 }
 
-@Component({ fork: true })
+@Component
 class View {
 
     @Attribute elements = [];
@@ -128,7 +128,7 @@ describe('@VirtualComponent decorator', () => {
             static items = new ObservableArray([ 1, 2, 3 ]);
         }
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <View elements={ elements } name={ Data.items.length }>
@@ -182,7 +182,7 @@ describe('@VirtualComponent decorator', () => {
             @Attribute x;
         }
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <View elements={ elements } name={ Data.items.length }>
@@ -221,7 +221,7 @@ describe('@VirtualComponent decorator', () => {
             static items = new ObservableArray([ 1, 2, 3 ]);
         }
 
-        @Component({ fork: true })
+        @Component
         class MyComponent {
             render() {
                 return <View elements={ elements } name={ Data.items.length }>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@twist/babel-plugin-transform-react@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@twist/babel-plugin-transform-react/-/babel-plugin-transform-react-0.1.0.tgz#2f0255e249b4ee362f849e99cd6a035ae58eb844"
+"@twist/babel-plugin-transform-react@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@twist/babel-plugin-transform-react/-/babel-plugin-transform-react-0.1.1.tgz#2d74eafff63e982d731942f1732a21e323de3bdb"
   dependencies:
     "@twist/babel-plugin-transform" "0.1.0"
     babel-core "^6.26.0"
@@ -78,8 +78,8 @@
     strip-json-comments "^2.0.1"
 
 "@twist/core@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@twist/core/-/core-0.1.0.tgz#079dac1b81da61c9406805fb4b744b0c5195cdcd"
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@twist/core/-/core-0.1.1.tgz#c59aa0d9096072e2774416342c3ebbe4f019b482"
 
 "@twist/eslint-plugin-core@^0.1.2":
   version "0.1.2"
@@ -89,10 +89,10 @@
     requireindex "1.1.0"
 
 "@twist/react-webpack-plugin@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@twist/react-webpack-plugin/-/react-webpack-plugin-0.1.0.tgz#3525981f40f8c06fdf6edc3aca56026d18af254c"
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@twist/react-webpack-plugin/-/react-webpack-plugin-0.1.1.tgz#ae1b8ef8b45d95601f1978f58f9c0e3f49ab2b86"
   dependencies:
-    "@twist/babel-plugin-transform-react" "0.1.0"
+    "@twist/babel-plugin-transform-react" "0.1.1"
     "@twist/configuration" "0.1.0"
     babel-loader "^7.1.2"
     thread-loader "^1.1.2"
@@ -1263,10 +1263,10 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     electron-to-chromium "^1.2.7"
 
 browserslist@^2.1.2:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.0.tgz#50350d6873a82ebe0f3ae5483658c571ae5f9d7d"
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
   dependencies:
-    caniuse-lite "^1.0.30000784"
+    caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
 
 browserslist@~1.3.5:
@@ -1357,12 +1357,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000515, caniuse-db@^1.0.30000525, caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000789"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000789.tgz#5cf3fec75480041ab162ca06413153141e234325"
+  version "1.0.30000793"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000793.tgz#3c00c66e423a7a1907c7dd96769a78b2afa8a72e"
 
-caniuse-lite@^1.0.30000784:
-  version "1.0.30000789"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000789.tgz#2e3d937b267133f63635ef7f441fac66360fc889"
+caniuse-lite@^1.0.30000792:
+  version "1.0.30000792"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz#d0cea981f8118f3961471afbb43c9a1e5bbf0332"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1527,7 +1527,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.12.x, commander@~2.12.1:
+commander@2.12.x:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
@@ -1536,6 +1536,10 @@ commander@2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@~2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -1913,9 +1917,13 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@1.1.1, depd@~1.1.1:
+depd@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
+
+depd@~1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -1967,8 +1975,8 @@ dns-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
 
 dns-packet@^1.0.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.2.2.tgz#a8a26bec7646438963fc86e06f8f8b16d6c8bf7a"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
   dependencies:
     ip "^1.1.0"
     safe-buffer "^5.0.1"
@@ -2048,15 +2056,9 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-releases@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/electron-releases/-/electron-releases-2.1.0.tgz#c5614bf811f176ce3c836e368a0625782341fd4e"
-
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
-  version "1.3.30"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz#9666f532a64586651fc56a72513692e820d06a80"
-  dependencies:
-    electron-releases "^2.1.0"
+  version "1.3.31"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz#00d832cba9fe2358652b0c48a8816c8e3a037e9f"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -2152,13 +2154,13 @@ error-ex@^1.2.0:
     is-arrayish "^0.2.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.37"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.37.tgz#0ee741d148b80069ba27d020393756af257defc3"
+  version "0.10.38"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.38.tgz#fa7d40d65bbc9bb8a67e1d3f9cc656a00530eed3"
   dependencies:
-    es6-iterator "~2.0.1"
+    es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"
 
-es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
   dependencies:
@@ -3334,8 +3336,8 @@ istanbul@^0.4.0:
     wordwrap "^1.0.0"
 
 js-base64@^2.1.9:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.0.tgz#9e566fee624751a1d720c966cd6226d29d4025aa"
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.1.tgz#e02813181cd53002888e918935467acb2910e596"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -3656,8 +3658,8 @@ log4js@^0.6.31:
     semver "~4.3.3"
 
 loglevel@^1.4.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.0.tgz#ae0caa561111498c5ba13723d6fb631d24003934"
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
 lolex@^1.6.0:
   version "1.6.0"
@@ -3886,8 +3888,8 @@ multicast-dns-service-types@^1.1.0:
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
 
 multicast-dns@^6.0.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.2.1.tgz#c5035defa9219d30640558a49298067352098060"
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.2.2.tgz#300b6133361f8aaaf2b8d1248e85c363fe5b95a0"
   dependencies:
     dns-packet "^1.0.1"
     thunky "^0.1.0"
@@ -4774,8 +4776,8 @@ randomatic@^1.1.3:
     kind-of "^4.0.0"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.5.tgz#dc009a246b8d09a177b4b7a0ae77bc570f4b1b79"
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.6.tgz#d302c522948588848a8d300c932b44c24231da80"
   dependencies:
     safe-buffer "^5.1.0"
 
@@ -4800,8 +4802,8 @@ raw-body@2.3.2:
     unpipe "1.0.0"
 
 rc@^1.1.7:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.3.tgz#51575a900f8dd68381c710b4712c2154c3e2035b"
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.4.tgz#a0f606caae2a3b862bbd0ef85482c0125b315fa3"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"
@@ -4865,7 +4867,7 @@ readable-stream@1.0, readable-stream@~1.0.2:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9, readable-stream@^2.3.3:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -5153,8 +5155,8 @@ selfsigned@^1.9.1:
     node-forge "0.6.33"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@~4.3.3:
   version "4.3.6"
@@ -5458,12 +5460,12 @@ stream-browserify@^2.0.1:
     readable-stream "^2.0.2"
 
 stream-http@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.2.tgz#40a050ec8dc3b53b33d9909415c02c0bf1abfbad"
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.0.tgz#fd86546dac9b1c91aff8fc5d287b98fafb41bc10"
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
-    readable-stream "^2.2.6"
+    readable-stream "^2.3.3"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
@@ -5729,8 +5731,8 @@ type-check@~0.3.2:
     prelude-ls "~1.1.2"
 
 type-detect@^4.0.0:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.5.tgz#d70e5bc81db6de2a381bcaca0c6e0cbdc7635de2"
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.6.tgz#88cbce3d13bc675a63f840b3225c180f870786d7"
 
 type-is@~1.6.15:
   version "1.6.15"
@@ -5748,10 +5750,10 @@ ua-parser-js@^0.7.9:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
 uglify-js@3.3.x:
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.5.tgz#4c4143dfe08e8825746675cc49a6874a933b543e"
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.7.tgz#28463e7c7451f89061d2b235e30925bf5625e14d"
   dependencies:
-    commander "~2.12.1"
+    commander "~2.13.0"
     source-map "~0.6.1"
 
 uglify-js@^2.6, uglify-js@^2.8.29:
@@ -5864,8 +5866,8 @@ uuid@^2.0.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
### What does this PR do?

Fixes #7 - forking is now true by default (write `@Component({ fork: false })` to disable forking), which means that users no longer have to worry about the top-level component being forked.

### Checklist

- [ ] I've read the [contribution guidelines](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [ ] An issue has been created for this PR
- [ ] Title begins with one of the following: `Fix:`, `Update:`, `Breaking:`, or `New:`
- [ ] Title ends with a reference to the related issue(s): `(fixes #issue)` or `(refs #issue)`
- [ ] Linting and unit tests all pass (`npm test`)
- [ ] PR includes new unit tests as necessary (or will be submitted as a separate PR)
- [ ] PR includes documentation as necessary (or will be forthcoming in a separate PR)
