### PR TITLE
Fix/components inside virtual

### DIFF
--- a/src/BaseVirtualComponent.jsx
+++ b/src/BaseVirtualComponent.jsx
@@ -31,7 +31,11 @@ function isConcreteComponent(item) {
 }
 
 function concreteItemTransform(item) {
-    return isConcreteComponent(item) ? item[_items] : item;
+    if (isConcreteComponent(item)) {
+        BinderRecordEvent(item, 'virtual.children');
+        return item[_items];
+    }
+    return item;
 }
 
 function flatten(arr, skipTest, itemTransform, flattenedArr) {
@@ -68,8 +72,9 @@ function instantiateContent(content, context) {
             instance[_dirty] = false;
             instance[_queuedUpdate] = false;
             instance[_items] = [];
-            instance.forceUpdate = BaseVirtualComponent.prototype.forceUpdate;
             instance[_virtualRender] = BaseVirtualComponent.prototype[_virtualRender];
+            instance.forceUpdate = BaseVirtualComponent.prototype.forceUpdate;
+
         }
         return instance;
     }

--- a/test/decorators/VirtualComponentTest.jsx
+++ b/test/decorators/VirtualComponentTest.jsx
@@ -302,6 +302,49 @@ describe('@VirtualComponent decorator', () => {
 
         let elements = [];
         render(<View elements={ elements }><DynamicList names={ [ 'T1', 'T2', 'T3' ] }/></View>);
+        assert.deepEqual(elements.map(e => e.textContent), [
+            '3',
+            'yes',
+            'T1,T2,T3'
+        ]);
+    });
+
+    it('@VirtualComponent with normal components inside it can update', () => {
+
+        class Switch {
+            @Observable static on = false;
+        }
+
+        @Component
+        class DynamicItem {
+            @Attribute name;
+            render() {
+                return <if condition={ Switch.on && this.name }>
+                    <Item name={ this.name } />
+                </if>;
+            }
+
+        }
+
+        @Component
+        class DynamicList {
+            @Attribute names;
+            render() {
+                return <repeat for={ name in this.names }>
+                    <DynamicItem name={ name } />
+                </repeat>;
+            }
+        }
+
+        let elements = [];
+        render(<View elements={ elements }><DynamicList names={ [ 'T1', 'T2', 'T3' ] }/></View>);
+        assert.deepEqual(elements.map(e => e.textContent), [
+            '0',
+            'no',
+            ''
+        ]);
+
+        Switch.on = true;
         TaskQueue.run();
         assert.deepEqual(elements.map(e => e.textContent), [
             '3',

--- a/test/decorators/VirtualComponentTest.jsx
+++ b/test/decorators/VirtualComponentTest.jsx
@@ -277,4 +277,37 @@ describe('@VirtualComponent decorator', () => {
         console.error.restore();
     });
 
+    it('@VirtualComponent can have normal components inside it', () => {
+
+        @Component
+        class DynamicItem {
+            @Attribute name;
+            render() {
+                return <if condition={ this.name }>
+                    <Item name={ this.name } />
+                </if>;
+            }
+
+        }
+
+        @Component
+        class DynamicList {
+            @Attribute names;
+            render() {
+                return <repeat for={ name in this.names }>
+                    <DynamicItem name={ name } />
+                </repeat>;
+            }
+        }
+
+        let elements = [];
+        render(<View elements={ elements }><DynamicList names={ [ 'T1', 'T2', 'T3' ] }/></View>);
+        TaskQueue.run();
+        assert.deepEqual(elements.map(e => e.textContent), [
+            '3',
+            'yes',
+            'T1,T2,T3'
+        ]);
+    });
+
 });


### PR DESCRIPTION
### What does this PR do?

Fixing so we can use real components inside of virtual ones - when we changed it so that virtual components don't have a render function, the idea was that custom render logic would be done in normal components - but since these don't have the virtual component methods, it doesn't work.

The fix here is to inject the few methods we need at instantiation time - it's a little ugly but it works. This means you could write a real component that renders its children, but doesn't care whether it's rendering UI or something virtual (e.g. for lazy loading, where the code is the same in both cases).

### Checklist

- [ ] I've read the [contribution guidelines](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [ ] An issue has been created for this PR
- [ ] Title begins with one of the following: `Fix:`, `Update:`, `Breaking:`, or `New:`
- [ ] Title ends with a reference to the related issue(s): `(fixes #issue)` or `(refs #issue)`
- [ ] Linting and unit tests all pass (`npm test`)
- [ ] PR includes new unit tests as necessary (or will be submitted as a separate PR)
- [ ] PR includes documentation as necessary (or will be forthcoming in a separate PR)
